### PR TITLE
Update shortcode_atts() Method

### DIFF
--- a/src/shortcodes/wp-gios-map-shortcodes.php
+++ b/src/shortcodes/wp-gios-map-shortcodes.php
@@ -131,7 +131,7 @@ class WP_GIOS_Map_Shortcodes extends Hook {
      * to our own functions.
      */
     shortcode_atts(
-      array( 'disclaimer' => false ),
+      array( 'disclaimer' => 'false' ),
       $atts,
       'gios_map'
     );


### PR DESCRIPTION
Turns out that the shortcode_atts() method really wants you to provide default attributes as strings. Updated the code so that the default value for 'disclaimer', our only attribute, as the string 'false', instead of a boolean.

We convert that value to a boolean on the next line, so we can pass it to the template file (which wants a boolean, and NOT a string!); we just need it to be a string initially.